### PR TITLE
feat: 支持监控所有 Secret 的证书过期时间

### DIFF
--- a/internal/controller/podmonitor_controller.go
+++ b/internal/controller/podmonitor_controller.go
@@ -29,13 +29,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics" // SDK 的 metrics 包
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // PodMonitorReconciler reconciles a PodMonitor object
@@ -158,13 +155,14 @@ func init() {
 //}
 
 func (r *PodMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// 判断是 Pod 还是 Secret 的事件
-	if req.Namespace == "linkerd" && req.Name == "linkerd-identity-issuer" {
-		// 处理 Secret 事件
+	// 尝试获取 Secret
+	var secret corev1.Secret
+	if err := r.Get(ctx, req.NamespacedName, &secret); err == nil {
+		// 如果是 Secret，处理证书监控
 		return r.reconcileSecret(ctx, req)
 	}
 
-	// 处理 Pod 事件
+	// 否则处理 Pod 事件
 	return r.reconcilePod(ctx, req)
 }
 
@@ -361,24 +359,13 @@ func (r *PodMonitorReconciler) checkCertificateExpiration(ctx context.Context, n
 	return nil
 }
 
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *PodMonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{}).
-		// 也监听 Secret 资源，特别是 linkerd 命名空间下的
-		Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool {
-					// 只关注 linkerd 命名空间下的 linkerd-identity-issuer secret
-					return e.Object.GetNamespace() == "linkerd" && e.Object.GetName() == "linkerd-identity-issuer"
-				},
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					return e.ObjectNew.GetNamespace() == "linkerd" && e.ObjectNew.GetName() == "linkerd-identity-issuer"
-				},
-				DeleteFunc: func(e event.DeleteEvent) bool {
-					return false // 不关注删除事件
-				},
-			})).
+		// 监听所有 Secret 对象
+		Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{}).
 		Named("podmonitor").
 		Complete(r)
 }


### PR DESCRIPTION
将证书监控逻辑从硬编码特定 namespace/secret 改为监控所有 Secret。
用户可以通过 Prometheus 查询自行选择要监控的证书：
pod_monitor_certificate_days_until_expiration{namespace="linkerd", secret_name="linkerd-policy-validator-k8s-tls"}

主要改动：
- 移除了 CertificateConfig 结构体和相关配置
- Reconcile 方法现在检查资源类型来判断是 Pod 还是 Secret
- SetupWithManager 监听所有 Secret 对象
- 移除了 LoadCertificateConfigs 函数

🤖 Generated with [Claude Code](https://claude.ai/code)